### PR TITLE
jsonc decoding with treesitter

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -2,6 +2,38 @@ local M = {}
 local uv = vim.loop
 local message = {}
 
+local function jsonc_no_comment(content)
+  local parser = vim.treesitter.get_string_parser(content, 'jsonc')
+  local tree = parser:parse()
+  local root = tree[1]:root()
+  -- create comment query
+  local query = vim.treesitter.parse_query('jsonc', '((comment) @c (#offset! @c))')
+  -- split content lines
+  local lines = vim.split(content, '\n')
+
+  -- iterate over query match metadata
+  for _, _, metadata in query:iter_matches(root, content, root:start(), root:end_()) do
+    local region = metadata.content[1]
+    local line = region[1] + 1
+    local col_start = region[2]
+    -- remove comment by extracting the text before
+    lines[line] = string.sub(lines[line], 1, col_start)
+  end
+  -- join lines
+  local result = vim.fn.join(lines, '\n')
+  return result
+end
+
+local function jsonc_no_trailing_comma(content)
+  return vim.fn.substitute(content, ',\\_s*}', '}', 'g')
+end
+
+local function jsonc_to_json(content)
+  content = jsonc_no_trailing_comma(content)
+  content = jsonc_no_comment(content)
+  return content
+end
+
 function M.systemChecks()
 	if not (vim.fn.executable("docker")) then
 		error("must install docker for this functionality")
@@ -18,7 +50,8 @@ function M.parseConfig(configType)
 	M.systemChecks()
 
 	-- TODO: Check current directory and the devcontainer
-	local parsedConfig = vim.fn.json_decode(vim.fn.join(vim.fn.readfile(".devcontainer/devcontainer.json")))
+  local config = vim.fn.join(vim.fn.readfile(".devcontainer/devcontainer.json"))
+	local parsedConfig = vim.fn.json_decode(jsonc_to_json(config))
 	if not parsedConfig.image and not parsedConfig.dockerComposeFile and not parsedConfig.dockerFile then
 		error("must have an image, dockerfile, or docker-compose file")
 		return


### PR DESCRIPTION
Remove comments and trailing whitespaces from json using treesitter before calling `json_decode`.
VSCode uses jsonc (json with comments) in its configuration files sometimes breaking calls to neovim `json_decode`.

This PR adds dependency to jsonc parser for treesitter.