### PR TITLE
fix iter_matches call for nvim 10

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -12,7 +12,7 @@ local function jsonc_no_comment(content)
   local lines = vim.split(content, '\n')
 
   -- iterate over query match metadata
-  for _, _, metadata in query:iter_matches(root, content, root:start(), root:end_()) do
+  for _, _, metadata in query:iter_matches(root, content, root:start(), root:end_(), nil) do
     local range = metadata[1].range
     local line = range[1] + 1
     local col_start = range[2]


### PR DESCRIPTION
The function signature for `iter_matches` changes in neovim 10 with [this PR](https://github.com/neovim/neovim/pull/22710). Omitting the argument from the function should have been safe from my understanding of the stack-based implementation of the lua interop with C, but the value at the position in the stack where this parameter was expected was `1`, which throws [this error](https://github.com/neovim/neovim/blob/87db6d894ad252edf69cd3382704c60d3115b51e/src/nvim/lua/treesitter.c#L1470-L1473) since it is neither nil nor a table.

This PR is opened as draft because this may not be desired until the upstream neovim 10 is released. For one reason or another I am on the dev builds of neovim, so I needed this fix.